### PR TITLE
Display a static list of servers

### DIFF
--- a/config/menus.cfg
+++ b/config/menus.cfg
@@ -11,10 +11,15 @@ bind ESCAPE [togglemainmenu]
 
 // hardcoded servers for testing till we have a new master server
 version = "0.9"
-autoupdateservers 0;
+// autoupdateservers 0;
 // addserver inexor.nooblounge.net;
-addserver game.noobys.org;
-addserver game.noobys.org 31444;
+// addserver game.noobys.org;
+// addserver game.noobys.org 31444;
+
+newgui servers_menu [
+    guibutton "Nooby's Colloseum"             "connect game.noobys.org"
+    guibutton "Nooby's Collective Creativity" "connect game.noobys.org 31444"
+]
 
 newgui main [
     guilist [
@@ -28,7 +33,7 @@ newgui main [
         guiimage (getcrosshair) [showgui crosshair] 0.5
     ]
     guibar
-	guibutton "server browser.."  "showgui servers"
+	guibutton "server browser.."  "showgui servers_menu"
     guibutton "bot match.."      "showgui botmatch"
 
     if (isconnected) [


### PR DESCRIPTION
The old serverbrowser is now gone.

The static list is better than nothing.

The current core client isn't able to connect to my servers. This should be gone as soon as we have documentation on how to host the and configure the current server.